### PR TITLE
Avoid renaming asset with only incoming pre-browsing directives

### DIFF
--- a/lib/hashfiles.js
+++ b/lib/hashfiles.js
@@ -93,6 +93,20 @@ module.exports = async function hashfiles(assetGraph, options = {}) {
             incomingRelations: { $not: { $size: 0 } }
           }
         ]
+      },
+      // Rule for pre-browsing directives where the target asset is not referenced by anything else
+      // than that directive:
+      // When a user asks the browser to preload an asset and we can't find the usage of said asset,
+      // we should assume that the user specified a loading mechanism Assetgraph is not capable
+      // of discovering. Moving these assets might break that loading mechanism.
+      // Keep asset with only incoming preload directives in place
+      {
+        incomingRelations: {
+          $where: relations =>
+            relations.some(
+              rel => !['HtmlPrefetchLink', 'HtmlPreloadLink'].includes(rel.type)
+            )
+        }
       }
     ]
   };

--- a/test/hashfiles.test.js
+++ b/test/hashfiles.test.js
@@ -122,6 +122,20 @@ describe('hashfiles', () => {
       ]);
     });
 
+    it('should keep preloaded assets that have no other incoming relation unhashed', async () => {
+      const graph = await getPopulatedGraph('unreferenced-preload', [
+        'index.html'
+      ]);
+
+      await hashFiles(graph);
+
+      expect(graph.findAssets({ isInline: false }), 'to satisfy', [
+        { fileName: 'index.html' },
+        { fileName: 'page-data.json' },
+        { fileName: 'page-data-2.cabd62c27f.json' }
+      ]);
+    });
+
     it('should hash static assets', async () => {
       const graph = new AssetGraph({
         root: resolve(__dirname, '../testdata', 'fullpage'),

--- a/testdata/unreferenced-preload/gatsby/page-data-2.json
+++ b/testdata/unreferenced-preload/gatsby/page-data-2.json
@@ -1,0 +1,3 @@
+{
+  "isReferenced": true
+}

--- a/testdata/unreferenced-preload/gatsby/page-data.json
+++ b/testdata/unreferenced-preload/gatsby/page-data.json
@@ -1,0 +1,3 @@
+{
+  "isReferenced": false
+}

--- a/testdata/unreferenced-preload/index.html
+++ b/testdata/unreferenced-preload/index.html
@@ -1,0 +1,7 @@
+<link rel="preload" href="/gatsby/page-data.json" as="fetch">
+<link rel="preload" href="/gatsby/page-data-2.json" as="fetch">
+
+<script>
+  fetch('/gatsby/' + 'page-data.json').then(response => response.json()).then(data => console.log(data));
+  fetch('/gatsby/page-data-2.json').then(response => response.json()).then(data => console.log(data));
+</script>


### PR DESCRIPTION
If a user explicitly preloads or prefetches an asset that Assetgraph has no other type of incoming relation to, we should assume that the asset is actually in use, but Assetgraph doesn't have the capability to discover the loading mechanism. Thus renaming is not safe.

Case in point: Gatsby page data being preloaded with a fetch call with a runtime evaluated URL

Fixes https://github.com/Munter/netlify-plugin-hashfiles/issues/108